### PR TITLE
smbk5pwd module does not build against Heimdal 7.x

### DIFF
--- a/contrib/slapd-modules/smbk5pwd/smbk5pwd.c
+++ b/contrib/slapd-modules/smbk5pwd/smbk5pwd.c
@@ -464,7 +464,7 @@ static int smbk5pwd_exop_passwd(
 		}
 
 		ret = hdb_generate_key_set_password(context, ent.principal,
-			qpw->rs_new.bv_val, &ent.keys.val, &nkeys);
+			qpw->rs_new.bv_val, NULL, 0, &ent.keys.val, &nkeys);
 		ent.keys.len = nkeys;
 		hdb_seal_keys(context, db, &ent);
 		krb5_free_principal( context, ent.principal );


### PR DESCRIPTION
The smbk5pwd module does not build against Heimdal 7.1.0 because the signature of hdb_generate_key_set_password has changed from:
hdb_generate_key_set_password(krb5_context context,
                              krb5_principal principal,
                              const char *password,
                              Key **keys, size_t *num_keys)

to:

hdb_generate_key_set_password_with_ks_tuple(krb5_context context,
                                            krb5_principal principal,
                                            const char *password,
                                            krb5_key_salt_tuple *ks_tuple,
                                            int n_ks_tuple,
                                            Key **keys, size_t *num_keys)
  
 Here is a proposed patch that allows it to build, and it works as intended