### PR TITLE
Open Directory Project URL curshed in intro.html

### DIFF
--- a/doc/guide/admin/intro.sdf
+++ b/doc/guide/admin/intro.sdf
@@ -51,7 +51,7 @@ a uniform {{namespace}} which gives the same view of the data no
 matter where you are in relation to the data itself.
 
 A web directory, such as provided by the {{Open Directory Project}}
-<{{URL:http://dmoz.org}}>, is a good example of a directory service.
+<{{URL:https://dmoz-odp.org/}}>, is a good example of a directory service.
 These services catalog web pages and are specifically designed to
 support browsing and searching.
 


### PR DESCRIPTION
The correct one might be https://dmoz-odp.org/

Signed-off-by: yuan ren <yren@suse.com>