### PR TITLE
add prereq step for building ppm.so

### DIFF
--- a/contrib/slapd-modules/ppm/INSTALL.md
+++ b/contrib/slapd-modules/ppm/INSTALL.md
@@ -11,6 +11,8 @@ ppm is provided along with OpenLDAP sources. By default, it is available into co
 
 Build
 -----
+Prerequisite: run `./configure && make depend` on openldap base source directory.
+
 Enter contrib/slapd-modules/ppm directory
 
 You can optionally customize some variables if you don't want the default ones:


### PR DESCRIPTION
to be copied to other machine as module, eg 3rd party installation like Ubuntu machine with `apt install slapd`