### PR TITLE
Update msuser.ldif

### DIFF
--- a/servers/slapd/schema/msuser.ldif
+++ b/servers/slapd/schema/msuser.ldif
@@ -3208,7 +3208,7 @@ olcAttributeTypes: ( MSADat4:675
 #
 # NO-USER-MODIFICATION
 olcAttributeTypes: ( MSADat2:102
-  NAME 'memberOf'
+  NAME 'MSADatmemberOf'
   SYNTAX '1.3.6.1.4.1.1466.115.121.1.12' )
 #
 olcAttributeTypes: ( MSADat4:690


### PR DESCRIPTION
The 'memberOf' attribute is part of InetOrgPerson/Core schema of Openldap. The attribute of the same name causes issues in loading the slapd and thus this name needs to be modified. I made the change to be random MSADatmemberOf but the developers of this project can hopefully modify the code in a way that it works with openldap core functionality