### PR TITLE
Reactivate "-mt" for pthread support on HP-UX (and Solaris)

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1338,7 +1338,7 @@ case $ol_with_threads in auto | yes | posix)
 		dnl 	pthread_create() in $LIBS
 		dnl
 		dnl Check special pthread (final) flags
-		dnl 	[skipped] pthread_create() with -mt (Solaris) [disabled]
+		dnl 	pthread_create() with -mt (Solaris/HP-UX)
 		dnl 	pthread_create() with -kthread (FreeBSD)
 		dnl 	pthread_create() with -pthread (FreeBSD/Digital Unix)
 		dnl 	pthread_create() with -pthreads (?)
@@ -1376,7 +1376,7 @@ case $ol_with_threads in auto | yes | posix)
 			ol_link_pthreads=""
 		fi
 
-dnl		OL_PTHREAD_TRY([-mt],		[ol_cv_pthread_mt])
+		OL_PTHREAD_TRY([-mt],		[ol_cv_pthread_mt])
 		OL_PTHREAD_TRY([-kthread],	[ol_cv_pthread_kthread])
 		OL_PTHREAD_TRY([-pthread],	[ol_cv_pthread_pthread])
 		OL_PTHREAD_TRY([-pthreads],	[ol_cv_pthread_pthreads])


### PR DESCRIPTION
HP-UX, along with Solaris, requires this compiler and linker flag to pass proper macros and add required libraries.

Adding just `-lpthread` is not enough, macros are missing. `-mt` does everything according to the manpage:
```
      -mt            Sets various -D flags to enable multi-threading.  Also
                     sets -lpthread.  +Oopenmp automatically implies -mt.
                     For details see HP C/aC++ Online Programmer's Guide.
```